### PR TITLE
Add option to not serve cluster resources as MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,22 @@ The MKP server provides access to Kubernetes resources through MCP resources. Th
 - Clustered resources: `k8s://clustered/{group}/{version}/{resource}/{name}`
 - Namespaced resources: `k8s://namespaced/{namespace}/{group}/{version}/{resource}/{name}`
 
+### Controlling Resource Discovery
+
+By default, MKP serves all Kubernetes resources as MCP resources, which provides useful context for LLMs. However, in large clusters with many resources, this can consume significant context space in the LLM.
+
+You can disable this behavior by using the `--serve-resources` flag:
+
+```bash
+# Run without serving cluster resources
+./build/mkp-server --serve-resources=false
+
+# Run with a specific kubeconfig without serving cluster resources
+./build/mkp-server --kubeconfig=/path/to/kubeconfig --serve-resources=false
+```
+
+Even with resource discovery disabled, the MCP tools (`get_resource`, `list_resources`, and `apply_resource`) remain fully functional, allowing you to interact with your Kubernetes cluster.
+
 ## Development
 
 ### Running tests

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ func main() {
 	// Parse command line flags
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig file. If not provided, in-cluster config will be used")
 	addr := flag.String("addr", ":8080", "Address to listen on")
+	serveResources := flag.Bool("serve-resources", true, "Whether to serve cluster resources as MCP resources. Setting to false can reduce context size for LLMs when working with large clusters")
 	flag.Parse()
 
 	// Create a context that can be cancelled
@@ -38,8 +39,13 @@ func main() {
 		log.Fatalf("Failed to create Kubernetes client: %v", err)
 	}
 
+	// Create MCP server config
+	config := &mcp.Config{
+		ServeResources: *serveResources,
+	}
+
 	// Create MCP server using the helper function
-	mcpServer := mcp.CreateServer(k8sClient)
+	mcpServer := mcp.CreateServer(k8sClient, config)
 
 	// Create SSE server
 	sseServer := mcp.CreateSSEServer(mcpServer)

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -44,8 +44,8 @@ func TestCreateSSEServer(t *testing.T) {
 	// Set the dynamic client
 	mockClient.SetDynamicClient(fakeDynamicClient)
 
-	// Create an MCP server
-	mcpServer := CreateServer(mockClient)
+	// Create an MCP server with default config
+	mcpServer := CreateServer(mockClient, nil)
 
 	assert.NotNil(t, mcpServer, "MCP server should not be nil")
 


### PR DESCRIPTION
This PR adds a `--serve-resources` flag to control whether to serve cluster resources as MCP resources. This is useful for large clusters where serving all resources might overwhelm an LLM's context window.

The implementation includes:

1. A new `Config` struct in `pkg/mcp/server.go` to hold configuration options
2. A `ServeResources` field in the config that defaults to true for backward compatibility
3. Modified `CreateServer` function to accept this config and conditionally add resources
4. Updated `main.go` to add the `--serve-resources` flag and pass the config
5. Added documentation to the README.md explaining the new flag

All tests are passing and there are no linting issues.

Fixes #8