### PR TITLE
Add parameters support to get_resource tool with LLM-friendly defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Parameters:
 - `namespace`: Namespace (required for namespaced resources)
 - `name` (required): Name of the resource to get
 - `subresource`: Subresource to get (e.g., status, scale, logs)
+- `parameters`: Optional parameters for the request (see examples below)
 
 Example:
 
@@ -122,6 +123,40 @@ Example:
   }
 }
 ```
+
+Example of getting logs from a specific container with parameters:
+
+```json
+{
+  "name": "get_resource",
+  "arguments": {
+    "resource_type": "namespaced",
+    "group": "",
+    "version": "v1",
+    "resource": "pods",
+    "namespace": "default",
+    "name": "my-pod",
+    "subresource": "logs",
+    "parameters": {
+      "container": "my-container",
+      "sinceSeconds": "3600",
+      "timestamps": "true",
+      "limitBytes": "102400"
+    }
+  }
+}
+```
+
+Available parameters for pod logs:
+- `container`: Specify which container to get logs from
+- `previous`: Get logs from previous container instance (true/false)
+- `sinceSeconds`: Only return logs newer than a relative duration in seconds
+- `sinceTime`: Only return logs after a specific time (RFC3339 format)
+- `timestamps`: Include timestamps on each line (true/false)
+- `limitBytes`: Maximum number of bytes to return
+
+Available parameters for regular resources:
+- `resourceVersion`: When specified, shows the resource at that particular version
 
 #### list_resources
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Available parameters for pod logs:
 - `sinceTime`: Only return logs after a specific time (RFC3339 format)
 - `timestamps`: Include timestamps on each line (true/false)
 - `limitBytes`: Maximum number of bytes to return
+- `tailLines`: Number of lines to return from the end of the logs
+
+By default, pod logs are limited to the last 100 lines and 32KB to avoid overwhelming the LLM's context window. These defaults can be overridden using the parameters above.
 
 Available parameters for regular resources:
 - `resourceVersion`: When specified, shows the resource at that particular version

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 // PodLogsFunc is a function type for getting pod logs
-type PodLogsFunc func(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error)
+type PodLogsFunc func(ctx context.Context, namespace, name string, parameters map[string]string) (*unstructured.Unstructured, error)
 
 // Client represents a Kubernetes client with discovery and dynamic capabilities
 type Client struct {
@@ -161,6 +161,16 @@ func (c *Client) SetDiscoveryClient(discoveryClient discovery.DiscoveryInterface
 func (c *Client) SetClientset(clientset kubernetes.Interface) {
 	// Store the interface directly, we'll use it through the interface methods
 	c.clientset = clientset
+}
+
+// SetPodLogsFunc sets the function used to get pod logs (for testing purposes)
+func (c *Client) SetPodLogsFunc(getPodLogs PodLogsFunc) {
+	c.getPodLogs = getPodLogs
+}
+
+// GetPodLogs returns the current pod logs function
+func (c *Client) GetPodLogs() PodLogsFunc {
+	return c.getPodLogs
 }
 
 // IsReady returns true if the client is ready to use

--- a/pkg/k8s/subresource.go
+++ b/pkg/k8s/subresource.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +16,8 @@ import (
 
 // GetResource gets a resource or its subresource
 // If subresource is empty, the main resource is returned
-func (c *Client) GetResource(ctx context.Context, gvr schema.GroupVersionResource, namespace, name, subresource string) (*unstructured.Unstructured, error) {
+// parameters is a map of string key-value pairs that can be used to customize the request
+func (c *Client) GetResource(ctx context.Context, gvr schema.GroupVersionResource, namespace, name, subresource string, parameters map[string]string) (*unstructured.Unstructured, error) {
 	if name == "" {
 		return nil, fmt.Errorf("resource name cannot be empty")
 	}
@@ -24,26 +27,37 @@ func (c *Client) GetResource(ctx context.Context, gvr schema.GroupVersionResourc
 
 	// Special handling for pod logs
 	if gvr.Resource == "pods" && subresource == "logs" {
-		return c.getPodLogs(ctx, namespace, name)
+		return c.getPodLogs(ctx, namespace, name, parameters)
+	}
+
+	// Create GetOptions with parameters
+	getOptions := metav1.GetOptions{}
+	
+	// Apply parameters to GetOptions
+	if parameters != nil {
+		// ResourceVersion - when specified with a watch call, shows changes that occur after that particular version of a resource
+		if resourceVersion, ok := parameters["resourceVersion"]; ok {
+			getOptions.ResourceVersion = resourceVersion
+		}
 	}
 
 	if namespace == "" {
 		// Clustered resource
 		if subresource == "" {
 			// Main resource
-			result, err = c.dynamicClient.Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+			result, err = c.dynamicClient.Resource(gvr).Get(ctx, name, getOptions)
 		} else {
 			// Subresource
-			result, err = c.dynamicClient.Resource(gvr).Get(ctx, name, metav1.GetOptions{}, subresource)
+			result, err = c.dynamicClient.Resource(gvr).Get(ctx, name, getOptions, subresource)
 		}
 	} else {
 		// Namespaced resource
 		if subresource == "" {
 			// Main resource
-			result, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			result, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, getOptions)
 		} else {
 			// Subresource
-			result, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{}, subresource)
+			result, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, getOptions, subresource)
 		}
 	}
 
@@ -55,9 +69,53 @@ func (c *Client) GetResource(ctx context.Context, gvr schema.GroupVersionResourc
 }
 
 // defaultGetPodLogs retrieves logs from a pod and returns them as an unstructured object
-func (c *Client) defaultGetPodLogs(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+func (c *Client) defaultGetPodLogs(ctx context.Context, namespace, name string, parameters map[string]string) (*unstructured.Unstructured, error) {
 	// We need to use the CoreV1 client for logs, as the dynamic client doesn't handle logs properly
 	podLogOpts := corev1.PodLogOptions{}
+	
+	// Apply parameters to PodLogOptions
+	// Note we don't follow nor tail the logs since we are not using a watcher,
+	// this is an MCP tool call after all.
+	if parameters != nil {
+		// Container name
+		if container, ok := parameters["container"]; ok {
+			podLogOpts.Container = container
+		}
+		
+		// Previous container logs
+		if previous, ok := parameters["previous"]; ok {
+			previousBool, _ := strconv.ParseBool(previous)
+			podLogOpts.Previous = previousBool
+		}
+		
+		// Since seconds
+		if sinceSeconds, ok := parameters["sinceSeconds"]; ok {
+			if seconds, err := strconv.ParseInt(sinceSeconds, 10, 64); err == nil {
+				podLogOpts.SinceSeconds = &seconds
+			}
+		}
+		
+		// Since time
+		if sinceTime, ok := parameters["sinceTime"]; ok {
+			if t, err := time.Parse(time.RFC3339, sinceTime); err == nil {
+				metaTime := metav1.NewTime(t)
+				podLogOpts.SinceTime = &metaTime
+			}
+		}
+		
+		// Timestamps
+		if timestamps, ok := parameters["timestamps"]; ok {
+			timestampsBool, _ := strconv.ParseBool(timestamps)
+			podLogOpts.Timestamps = timestampsBool
+		}
+		
+		// Limit bytes
+		if limitBytes, ok := parameters["limitBytes"]; ok {
+			if bytes, err := strconv.ParseInt(limitBytes, 10, 64); err == nil {
+				podLogOpts.LimitBytes = &bytes
+			}
+		}
+	}
 	
 	// Get the REST client for pods
 	req := c.clientset.CoreV1().Pods(namespace).GetLogs(name, &podLogOpts)

--- a/pkg/k8s/subresource_test.go
+++ b/pkg/k8s/subresource_test.go
@@ -66,7 +66,7 @@ func TestGetResource(t *testing.T) {
 	client.SetClientset(fakeClientset)
 
 	// Mock the getPodLogs method
-	getPodLogsMock := func(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	getPodLogsMock := func(ctx context.Context, namespace, name string, parameters map[string]string) (*unstructured.Unstructured, error) {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",
@@ -101,6 +101,7 @@ func TestGetResource(t *testing.T) {
 		errorMsg     string
 		gvr          schema.GroupVersionResource
 		checkLogs    bool
+		parameters   map[string]string
 	}{
 		{
 			name:         "Get clustered resource",
@@ -136,6 +137,15 @@ func TestGetResource(t *testing.T) {
 			gvr:          schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			checkLogs:    true,
 		},
+		{
+			name:         "Get resource with resourceVersion parameter",
+			namespace:    "default",
+			resourceName: "test-deployment",
+			subresource:  "",
+			expectError:  false,
+			gvr:          deploymentGVR,
+			parameters:   map[string]string{"resourceVersion": "12345"},
+		},
 	}
 	
 	// Run test cases
@@ -143,7 +153,7 @@ func TestGetResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Call the method
 			ctx := context.Background()
-			result, err := client.GetResource(ctx, tc.gvr, tc.namespace, tc.resourceName, tc.subresource)
+			result, err := client.GetResource(ctx, tc.gvr, tc.namespace, tc.resourceName, tc.subresource, tc.parameters)
 			
 			// Assert expectations
 			if tc.expectError {
@@ -184,7 +194,7 @@ func TestGetPodLogs(t *testing.T) {
 	client := &Client{}
 	
 	// Create a mock implementation of getPodLogs
-	mockGetPodLogs := func(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	mockGetPodLogs := func(ctx context.Context, namespace, name string, parameters map[string]string) (*unstructured.Unstructured, error) {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",
@@ -204,7 +214,7 @@ func TestGetPodLogs(t *testing.T) {
 	// Call the method through the GetResource method
 	ctx := context.Background()
 	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	result, err := client.GetResource(ctx, podGVR, "default", "test-pod", "logs")
+	result, err := client.GetResource(ctx, podGVR, "default", "test-pod", "logs", nil)
 	
 	// Assert expectations
 	assert.NoError(t, err)

--- a/pkg/mcp/get_resource.go
+++ b/pkg/mcp/get_resource.go
@@ -102,6 +102,6 @@ func NewGetResourceTool() mcp.Tool {
 		mcp.WithString("subresource",
 			mcp.Description("Subresource to get (e.g., status, scale, logs)")),
 		mcp.WithObject("parameters",
-			mcp.Description("Optional parameters for the request. For regular resources: resourceVersion. For pod logs: container, previous, sinceSeconds, sinceTime, timestamps, limitBytes")),
+			mcp.Description("Optional parameters for the request. For regular resources: resourceVersion. For pod logs: container, previous, sinceSeconds, sinceTime, timestamps, limitBytes, tailLines")),
 	)
 }

--- a/pkg/mcp/get_resource_test.go
+++ b/pkg/mcp/get_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/StacklokLabs/mkp/pkg/k8s"
@@ -23,7 +23,7 @@ func TestHandleGetResourceClusteredSuccess(t *testing.T) {
 	// Create a fake dynamic client
 	scheme := runtime.NewScheme()
 	
-	fakeDynamicClient := fake.NewSimpleDynamicClient(scheme)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
 	
 	// Add a fake get response
 	fakeDynamicClient.PrependReactor("get", "deployments", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -88,7 +88,7 @@ func TestHandleGetResourceNamespacedSuccess(t *testing.T) {
 	// Create a fake dynamic client
 	scheme := runtime.NewScheme()
 	
-	fakeDynamicClient := fake.NewSimpleDynamicClient(scheme)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
 	
 	// Add a fake get response
 	fakeDynamicClient.PrependReactor("get", "deployments", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -149,6 +149,89 @@ func TestHandleGetResourceNamespacedSuccess(t *testing.T) {
 	assert.Contains(t, textContent.Text, "default", "Result should contain the namespace")
 }
 
+func TestHandleGetResourceWithParameters(t *testing.T) {
+	// Create a mock k8s client
+	mockClient := &k8s.Client{}
+	
+	// Create a fake dynamic client
+	scheme := runtime.NewScheme()
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	
+	// Set the dynamic client
+	mockClient.SetDynamicClient(fakeDynamicClient)
+	
+	// Create a mock implementation for getPodLogs that verifies parameters
+	mockGetPodLogs := func(ctx context.Context, namespace, name string, parameters map[string]string) (*unstructured.Unstructured, error) {
+		// Verify parameters were passed correctly
+		assert.Equal(t, "test-pod", name)
+		assert.Equal(t, "default", namespace)
+		assert.NotNil(t, parameters)
+		
+		// Check specific parameters
+		container, hasContainer := parameters["container"]
+		assert.True(t, hasContainer)
+		assert.Equal(t, "my-container", container)
+		
+		sinceSeconds, hasSinceSeconds := parameters["sinceSeconds"]
+		assert.True(t, hasSinceSeconds)
+		assert.Equal(t, "3600", sinceSeconds)
+		
+		// Return mock logs
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": namespace,
+				},
+				"logs": "test logs with parameters",
+			},
+		}, nil
+	}
+	
+	// Set our mock implementation
+	mockClient.SetPodLogsFunc(mockGetPodLogs)
+	
+	// Create an implementation
+	impl := NewImplementation(mockClient)
+	
+	// Create a test request with parameters
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "get_resource"
+	request.Params.Arguments = map[string]interface{}{
+		"resource_type": "namespaced",
+		"group":         "",
+		"version":       "v1",
+		"resource":      "pods",
+		"namespace":     "default",
+		"name":          "test-pod",
+		"subresource":   "logs",
+		"parameters": map[string]interface{}{
+			"container":    "my-container",
+			"sinceSeconds": "3600",
+		},
+	}
+	
+	// Test HandleGetResource
+	ctx := context.Background()
+	result, err := impl.HandleGetResource(ctx, request)
+	
+	// Verify there was no error
+	assert.NoError(t, err, "HandleGetResource should not return an error")
+	
+	// Verify the result is not nil
+	assert.NotNil(t, result, "Result should not be nil")
+	
+	// Verify the result is successful
+	assert.False(t, result.IsError, "Result should not be an error")
+	
+	// Verify the result contains the logs
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	assert.True(t, ok, "Content should be TextContent")
+	assert.Contains(t, textContent.Text, "test logs with parameters", "Result should contain the logs")
+}
+
 func TestHandleGetResourceWithSubresource(t *testing.T) {
 	// Create a mock k8s client
 	mockClient := &k8s.Client{}
@@ -156,7 +239,7 @@ func TestHandleGetResourceWithSubresource(t *testing.T) {
 	// Create a fake dynamic client
 	scheme := runtime.NewScheme()
 	
-	fakeDynamicClient := fake.NewSimpleDynamicClient(scheme)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
 	
 	// Add a fake get response for subresource
 	// Note: The fake client doesn't fully support subresources, so we're simulating it


### PR DESCRIPTION
# Add parameters support to get_resource tool with LLM-friendly defaults

This PR adds support for passing parameters to the `get_resource` tool in the MCP implementation, with a focus on making it work well with LLMs.

## Changes

### First Commit: Add parameters to the `get_resource` tool
- Added a new `parameters` object parameter to the tool definition
- Modified the k8s client to accept and use these parameters
- Implemented special handling for pod logs parameters (container, previous, sinceSeconds, etc.)
- Added support for resourceVersion parameter for regular resources
- Added comprehensive tests and documentation

### Second Commit: Add LLM-friendly defaults for pod logs
- Added reasonable defaults for pod logs to prevent overwhelming LLM context windows:
  - Limited to the last 100 lines by default
  - Limited to 32KB by default
- Added tailLines parameter support
- Updated documentation to explain defaults and parameters

## Benefits
- More flexible and powerful MCP implementation
- Better control over resource retrieval, especially for pod logs
- LLM-friendly defaults prevent context window overflow
- Comprehensive documentation and examples in README

## Testing
- All tests are passing
- Code passes linting checks for the entire package
- Manually verified parameter handling for pod logs and regular resources

This enhancement makes the MCP more flexible while ensuring it works well within the constraints of LLM context windows.