### PR TITLE
Minimize list_resources output by returning only metadata

### DIFF
--- a/pkg/mcp/list_resources_test.go
+++ b/pkg/mcp/list_resources_test.go
@@ -87,10 +87,13 @@ func TestHandleListResourcesClusteredSuccess(t *testing.T) {
 	// Verify the result is successful
 	assert.False(t, result.IsError, "Result should not be an error")
 	
-	// Verify the result contains the resource name
+	// Verify the result contains the resource name in a PartialObjectMetadataList
 	textContent, ok := mcp.AsTextContent(result.Content[0])
 	assert.True(t, ok, "Content should be TextContent")
 	assert.Contains(t, textContent.Text, "test-cluster-role", "Result should contain the resource name")
+	assert.Contains(t, textContent.Text, "meta.k8s.io/v1", "Result should contain the meta.k8s.io/v1 API version")
+	assert.Contains(t, textContent.Text, "PartialObjectMetadataList", "Result should be a PartialObjectMetadataList")
+	assert.NotContains(t, textContent.Text, "rules", "Result should not contain the rules field")
 }
 
 func TestHandleListResourcesNamespacedSuccess(t *testing.T) {
@@ -164,10 +167,13 @@ func TestHandleListResourcesNamespacedSuccess(t *testing.T) {
 	// Verify the result is successful
 	assert.False(t, result.IsError, "Result should not be an error")
 	
-	// Verify the result contains the resource name
+	// Verify the result contains the resource name in a PartialObjectMetadataList
 	textContent, ok := mcp.AsTextContent(result.Content[0])
 	assert.True(t, ok, "Content should be TextContent")
 	assert.Contains(t, textContent.Text, "test-service", "Result should contain the service name")
+	assert.Contains(t, textContent.Text, "meta.k8s.io/v1", "Result should contain the meta.k8s.io/v1 API version")
+	assert.Contains(t, textContent.Text, "PartialObjectMetadataList", "Result should be a PartialObjectMetadataList")
+	assert.NotContains(t, textContent.Text, "spec", "Result should not contain the spec field")
 }
 
 func TestHandleListResourcesMissingParameters(t *testing.T) {
@@ -466,4 +472,120 @@ func TestHandleListAllResourcesError(t *testing.T) {
 	
 	// Verify the result is nil
 	assert.Nil(t, resources, "Resources should be nil")
+}
+
+func TestHandleListResourcesWithLastAppliedConfig(t *testing.T) {
+	// Create a mock k8s client
+	mockClient := &k8s.Client{}
+	
+	// Create a fake dynamic client
+	scheme := runtime.NewScheme()
+	
+	// Register list kinds for the resources we'll be testing
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
+	}
+	
+	fakeDynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	
+	// Add a fake list response with the last-applied-configuration annotation
+	fakeDynamicClient.PrependReactor("list", "deployments", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		// Create a large last-applied-configuration annotation
+		lastAppliedConfig := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"test-deployment","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"test"}},"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"test-container","image":"nginx:latest","ports":[{"containerPort":80}]}]}}}}`
+		
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name":      "test-deployment",
+							"namespace": "default",
+							"annotations": map[string]interface{}{
+								"kubectl.kubernetes.io/last-applied-configuration": lastAppliedConfig,
+								"deployment.kubernetes.io/revision":               "1",
+							},
+						},
+						"spec": map[string]interface{}{
+							"replicas": int64(3),
+							"selector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"app": "test",
+								},
+							},
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"app": "test",
+									},
+								},
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "test-container",
+											"image": "nginx:latest",
+											"ports": []interface{}{
+												map[string]interface{}{
+													"containerPort": int64(80),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return true, list, nil
+	})
+	
+	// Set the dynamic client
+	mockClient.SetDynamicClient(fakeDynamicClient)
+	
+	// Create an implementation
+	impl := NewImplementation(mockClient)
+	
+	// Create a test request
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "list_resources"
+	request.Params.Arguments = map[string]interface{}{
+		"resource_type": "namespaced",
+		"group":         "apps",
+		"version":       "v1",
+		"resource":      "deployments",
+		"namespace":     "default",
+	}
+	
+	// Test HandleListResources
+	ctx := context.Background()
+	result, err := impl.HandleListResources(ctx, request)
+	
+	// Verify there was no error
+	assert.NoError(t, err, "HandleListResources should not return an error")
+	
+	// Verify the result is not nil
+	assert.NotNil(t, result, "Result should not be nil")
+	
+	// Verify the result is successful
+	assert.False(t, result.IsError, "Result should not be an error")
+	
+	// Get the text content
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	assert.True(t, ok, "Content should be TextContent")
+	
+	// Verify the result contains the deployment name
+	assert.Contains(t, textContent.Text, "test-deployment", "Result should contain the deployment name")
+	
+	// Verify the result contains the other annotation
+	assert.Contains(t, textContent.Text, "deployment.kubernetes.io/revision", "Result should contain other annotations")
+	
+	// Verify the result does not contain the last-applied-configuration annotation
+	assert.NotContains(t, textContent.Text, "kubectl.kubernetes.io/last-applied-configuration",
+		"Result should not contain the kubectl.kubernetes.io/last-applied-configuration annotation")
+	
+	// Verify the result does not contain the spec field
+	assert.NotContains(t, textContent.Text, "spec", "Result should not contain the spec field")
 }


### PR DESCRIPTION
This PR modifies the list_resources tool to return only metadata instead of the full resource details, significantly reducing the amount of data returned. It also removes the kubectl.kubernetes.io/last-applied-configuration annotation, which can be very large and would defeat the purpose of the optimization.