### PR TITLE
Add MCP tool annotations

### DIFF
--- a/pkg/mcp/delete_resource.go
+++ b/pkg/mcp/delete_resource.go
@@ -85,5 +85,10 @@ func NewDeleteResourceTool() mcp.Tool {
 		mcp.WithString("name",
 			mcp.Description("Name of the resource to delete"),
 			mcp.Required()),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:          "Delete a Kubernetes resource",
+			ReadOnlyHint:   false,
+			IdempotentHint: true,
+		}),
 	)
 }

--- a/pkg/mcp/get_resource.go
+++ b/pkg/mcp/get_resource.go
@@ -19,7 +19,7 @@ func (m *Implementation) HandleGetResource(ctx context.Context, request mcp.Call
 	namespace := mcp.ParseString(request, "namespace", "")
 	name := mcp.ParseString(request, "name", "")
 	subresource := mcp.ParseString(request, "subresource", "")
-	
+
 	// Parse parameters for subresources
 	var parameters map[string]string
 	if paramsRaw, exists := request.Params.Arguments["parameters"]; exists && paramsRaw != nil {
@@ -103,5 +103,9 @@ func NewGetResourceTool() mcp.Tool {
 			mcp.Description("Subresource to get (e.g., status, scale, logs)")),
 		mcp.WithObject("parameters",
 			mcp.Description("Optional parameters for the request. For regular resources: resourceVersion. For pod logs: container, previous, sinceSeconds, sinceTime, timestamps, limitBytes, tailLines")),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:        "Get Kubernetes resource",
+			ReadOnlyHint: true,
+		}),
 	)
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -21,6 +21,10 @@ func NewListResourcesTool() mcp.Tool {
 			mcp.Required()),
 		mcp.WithString("namespace",
 			mcp.Description("Namespace (required for namespaced resources)")),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:        "List Kubernetes resources",
+			ReadOnlyHint: true,
+		}),
 	)
 }
 
@@ -44,6 +48,11 @@ func NewApplyResourceTool() mcp.Tool {
 		mcp.WithObject("manifest",
 			mcp.Description("Resource manifest"),
 			mcp.Required()),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:          "Apply (create or update) a Kubernetes resource",
+			ReadOnlyHint:   false,
+			IdempotentHint: true,
+		}),
 	)
 }
 


### PR DESCRIPTION
Add annotations to the tools based on https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations.