### PR TITLE
Fix context canceled errors

### DIFF
--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -1,0 +1,24 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// WithTimeoutContext adds a timeout context to all tool handlers
+// This helps prevent context cancellation errors from the k8s client
+func WithTimeoutContext(timeout time.Duration) server.ServerOption {
+	return server.WithToolHandlerMiddleware(func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, request mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
+			// Create a new context with the specified timeout
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			// Call the next handler with the timeout context
+			return next(timeoutCtx, request)
+		}
+	})
+}


### PR DESCRIPTION
There is likely an issue with the default ctx that gets passed into tool calls by the `mark3labs/mcp-go` library, which passes in a ctx with a timeout of 0s.
This leads to errors like this during calls to the k8s apiserver:
```
2025/05/07 21:36:07 Context error while listing resources: context canceled
2025/05/07 21:36:07 Rate limiter error: client rate limiter Wait returned an error: context canceled
```

To fix this, we add middleware to the server which injects a custom ctx with a longer timeout (default 30s).
This bypasses the "context canceled" issues!