### PR TITLE
fix: Add missing pagination parameters to list_resources tool

### DIFF
--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -31,6 +31,10 @@ func NewListResourcesTool() mcp.Tool {
 			mcp.Description("List of annotation keys to exclude from output (supports wildcards with *)")),
 		mcp.WithArray("include_annotation_keys",
 			mcp.Description("List of annotation keys to include in output (if specified, only these are included)")),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of resources to return (0 means no limit, default: 0)")),
+		mcp.WithString("continue",
+			mcp.Description("Continue token for pagination (use the value from previous response's ListMeta.Continue)")),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			Title:        "List Kubernetes resources",
 			ReadOnlyHint: BoolPtr(true),


### PR DESCRIPTION
## Description

This PR adds the missing pagination parameters (`limit` and `continue`) to the MCP tool schema definition for the `list_resources` tool.

## Problem

The pagination functionality was already implemented in the backend (in `pkg/k8s/client.go` and `pkg/mcp/list_resources.go`), but the MCP tool schema definition in `pkg/mcp/tools.go` was missing the parameter declarations. This meant that:
- The parameters weren't visible in the tool's schema
- MCP clients couldn't see or use these parameters properly
- The tool documentation was incomplete

## Solution

Added the missing parameter definitions to the `NewListResourcesTool()` function:
- `limit` (number): Maximum number of resources to return (0 means no limit, default: 0)
- `continue` (string): Continue token for pagination (use the value from previous response's ListMeta.Continue)

## Changes

- Added `mcp.WithNumber("limit", ...)` parameter definition
- Added `mcp.WithString("continue", ...)` parameter definition

## Testing

The pagination functionality itself was already tested in the previous PR. This change only updates the schema definition to match the existing implementation.

## Impact

This is a non-breaking change that:
- ✅ Makes the pagination parameters visible in the tool schema
- ✅ Improves tool documentation and discoverability
- ✅ Allows MCP clients to properly use pagination
- ✅ Maintains backward compatibility