### PR TITLE
chore: fix lint issues and bump Go to 1.26.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
           - errcheck
           - dupl
           - gosec
+          - goconst
           - paralleltest
         path: (.+)_test\.go
       - linters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/StacklokLabs/mkp
 
-go 1.25.5
+go 1.26.3
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -71,14 +73,6 @@ github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLO
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.46.0 h1:8KRibF4wcKejbLsHxCA/QBVUr5fQ9nwz/n8lGqmaALo=
-github.com/mark3labs/mcp-go v0.46.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
-github.com/mark3labs/mcp-go v0.47.1 h1:A9sJJ20mscl/ssLYHjodfaoBmq6uuhMG7pAPNYaQymQ=
-github.com/mark3labs/mcp-go v0.47.1/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
-github.com/mark3labs/mcp-go v0.48.0 h1:o+MXuGW/HCeR2ny5LcAcZQn2bo6I2xaZMEHnpRG+dtw=
-github.com/mark3labs/mcp-go v0.48.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
-github.com/mark3labs/mcp-go v0.49.0 h1:7Ssx4d7/T86qnWoJIdye7wEEvUzv39UIbnZb/FqUZMY=
-github.com/mark3labs/mcp-go v0.49.0/go.mod h1:BflTAZAzXlrTpiO44gmjMu89n2FO56rJ9m31fp4zd5k=
 github.com/mark3labs/mcp-go v0.51.0 h1:e8AhEfxzcYt7XqYzwT7uzWNhnqpu3H1Tn7dEJB9Ygj8=
 github.com/mark3labs/mcp-go v0.51.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -51,13 +51,19 @@ func FromContext(ctx context.Context) *Identity {
 	return id
 }
 
+// Default JWT claim names used when no override is configured.
+const (
+	DefaultUserClaim   = "email"
+	DefaultGroupsClaim = "groups"
+)
+
 // Config holds configuration for identity extraction from JWTs.
 type Config struct {
 	// UserClaim is the JWT claim to use for the impersonated username.
-	// Defaults to "email".
+	// Defaults to DefaultUserClaim.
 	UserClaim string
 	// GroupsClaim is the JWT claim to use for impersonated groups.
-	// Defaults to "groups".
+	// Defaults to DefaultGroupsClaim.
 	GroupsClaim string
 	// JWKSClient is an optional JWKS client for JWT signature validation.
 	// When set, JWTs are validated against the keys from the JWKS endpoint
@@ -77,8 +83,8 @@ type Config struct {
 // DefaultConfig returns a Config with default claim names.
 func DefaultConfig() *Config {
 	return &Config{
-		UserClaim:   "email",
-		GroupsClaim: "groups",
+		UserClaim:   DefaultUserClaim,
+		GroupsClaim: DefaultGroupsClaim,
 	}
 }
 

--- a/pkg/identity/jwks_test.go
+++ b/pkg/identity/jwks_test.go
@@ -48,15 +48,24 @@ func rsaJWKSKey(kid string, pub *rsa.PublicKey) map[string]string {
 }
 
 // ecJWKSKey returns a JWKS key entry for the given ECDSA public key.
-func ecJWKSKey(kid string, pub *ecdsa.PublicKey) map[string]string {
+func ecJWKSKey(t *testing.T, kid string, pub *ecdsa.PublicKey) map[string]string {
+	t.Helper()
+	// pub.Bytes returns the uncompressed point (0x04 || X || Y); split it
+	// back into the coordinate halves the JWK encoding expects. The deprecated
+	// pub.X / pub.Y access path was removed in Go 1.26.
+	pt, err := pub.Bytes()
+	require.NoError(t, err)
+	size := (pub.Curve.Params().BitSize + 7) / 8
+	x := pt[1 : 1+size]
+	y := pt[1+size : 1+2*size]
 	return map[string]string{
 		"kty": "EC",
 		"use": "sig",
 		"kid": kid,
 		"alg": "ES256",
 		"crv": "P-256",
-		"x":   base64.RawURLEncoding.EncodeToString(pub.X.Bytes()),
-		"y":   base64.RawURLEncoding.EncodeToString(pub.Y.Bytes()),
+		"x":   base64.RawURLEncoding.EncodeToString(x),
+		"y":   base64.RawURLEncoding.EncodeToString(y),
 	}
 }
 
@@ -194,7 +203,7 @@ func TestExtractFromJWT_WithRSAJWKSValidation(t *testing.T) {
 func TestExtractFromJWT_WithECDSAJWKSValidation(t *testing.T) {
 	key := testECKeyPair(t)
 	kid := "ec-key-1"
-	srv := serveJWKS(t, ecJWKSKey(kid, &key.PublicKey))
+	srv := serveJWKS(t, ecJWKSKey(t, kid, &key.PublicKey))
 
 	jwksClient, err := NewJWKSClient(context.Background(), srv.URL)
 	require.NoError(t, err)
@@ -252,7 +261,7 @@ func TestExtractFromJWT_WithMixedKeyTypes(t *testing.T) {
 	// Serve both RSA and EC keys from the same JWKS endpoint
 	srv := serveJWKS(t,
 		rsaJWKSKey(rsaKid, &rsaKey.PublicKey),
-		ecJWKSKey(ecKid, &ecKey.PublicKey),
+		ecJWKSKey(t, ecKid, &ecKey.PublicKey),
 	)
 
 	jwksClient, err := NewJWKSClient(context.Background(), srv.URL)

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -1,0 +1,25 @@
+package k8s
+
+// Repeated string literals used when building unstructured Kubernetes
+// objects or matching well-known resource/subresource names. Extracted
+// to satisfy goconst and to make changes (e.g. a typo in a JSON key)
+// fail in one place rather than many.
+const (
+	fieldAPIVersion = "apiVersion"
+	fieldKind       = "kind"
+	fieldMetadata   = "metadata"
+	fieldName       = "name"
+	fieldNamespace  = "namespace"
+	fieldSpec       = "spec"
+	fieldStatus     = "status"
+	fieldCommand    = "command"
+	fieldStdout     = "stdout"
+	fieldStderr     = "stderr"
+	fieldError      = "error"
+	fieldLogs       = "logs"
+
+	apiVersionV1    = "v1"
+	kindPod         = "Pod"
+	resourcePods    = "pods"
+	subresourceExec = "exec"
+)

--- a/pkg/k8s/exec.go
+++ b/pkg/k8s/exec.go
@@ -49,10 +49,10 @@ func (c *Client) defaultExecInPod(
 
 	// Create the exec request
 	req := c.clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
+		Resource(resourcePods).
 		Name(name).
 		Namespace(namespace).
-		SubResource("exec")
+		SubResource(subresourceExec)
 
 	// Set query parameters
 	option := &corev1.PodExecOptions{
@@ -91,32 +91,32 @@ func (c *Client) defaultExecInPod(
 	// Create an unstructured object with the result
 	result := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
+			fieldAPIVersion: apiVersionV1,
+			fieldKind:       kindPod,
+			fieldMetadata: map[string]interface{}{
+				fieldName:      name,
+				fieldNamespace: namespace,
 			},
-			"spec": map[string]interface{}{
-				"command": command,
+			fieldSpec: map[string]interface{}{
+				fieldCommand: command,
 			},
-			"status": map[string]interface{}{
-				"stdout": stdout.String(),
-				"stderr": stderr.String(),
-				"error":  "",
+			fieldStatus: map[string]interface{}{
+				fieldStdout: stdout.String(),
+				fieldStderr: stderr.String(),
+				fieldError:  "",
 			},
 		},
 	}
 
 	// Check if the command was killed due to timeout
 	if execCtx.Err() == context.DeadlineExceeded {
-		result.Object["status"].(map[string]interface{})["error"] = "command timed out"
+		result.Object[fieldStatus].(map[string]interface{})[fieldError] = "command timed out"
 		return result, nil
 	}
 
 	// Check for other errors
 	if err != nil {
-		result.Object["status"].(map[string]interface{})["error"] = err.Error()
+		result.Object[fieldStatus].(map[string]interface{})[fieldError] = err.Error()
 		return result, nil
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) handlePodExec(
 	body map[string]interface{},
 ) (*unstructured.Unstructured, error) {
 	// Extract command from body
-	commandInterface, ok := body["command"]
+	commandInterface, ok := body[fieldCommand]
 	if !ok {
 		return nil, fmt.Errorf("command is required for pod exec")
 	}
@@ -190,7 +190,7 @@ func (c *Client) PostResource(
 	}
 
 	// Special handling for pod exec
-	if gvr.Resource == "pods" && subresource == "exec" {
+	if gvr.Resource == resourcePods && subresource == subresourceExec {
 		return c.handlePodExec(ctx, namespace, name, body)
 	}
 

--- a/pkg/k8s/subresource.go
+++ b/pkg/k8s/subresource.go
@@ -29,7 +29,7 @@ func (c *Client) GetResource(ctx context.Context,
 	var err error
 
 	// Special handling for pod logs
-	if gvr.Resource == "pods" && subresource == "logs" {
+	if gvr.Resource == resourcePods && subresource == fieldLogs {
 		return c.getPodLogs(ctx, namespace, name, parameters)
 	}
 
@@ -120,13 +120,13 @@ func (c *Client) defaultGetPodLogs(
 	// Create an unstructured object with the logs
 	result := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
+			fieldAPIVersion: apiVersionV1,
+			fieldKind:       kindPod,
+			fieldMetadata: map[string]interface{}{
+				fieldName:      name,
+				fieldNamespace: namespace,
 			},
-			"logs": buf.String(),
+			fieldLogs: buf.String(),
 		},
 	}
 

--- a/pkg/mcp/constants.go
+++ b/pkg/mcp/constants.go
@@ -1,0 +1,18 @@
+package mcp
+
+// Resource scope identifiers accepted by tools that operate on
+// either cluster-scoped or namespaced Kubernetes resources.
+const (
+	resourceTypeClustered  = "clustered"
+	resourceTypeNamespaced = "namespaced"
+)
+
+// MIME types and well-known annotation keys reused across tool/resource
+// definitions.
+const (
+	mimeTypeJSON = "application/json"
+
+	// kubectlLastAppliedAnnotation is excluded from default tool output
+	// because it duplicates the manifest body and bloats LLM context.
+	kubectlLastAppliedAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+)

--- a/pkg/mcp/list_resources.go
+++ b/pkg/mcp/list_resources.go
@@ -38,7 +38,7 @@ func (m *Implementation) HandleListResources(ctx context.Context, request mcp.Ca
 	// Parse new annotation filtering parameters
 	includeAnnotations := request.GetBool("include_annotations", true)
 	excludeAnnotationKeys := request.GetStringSlice(
-		"exclude_annotation_keys", []string{"kubectl.kubernetes.io/last-applied-configuration"})
+		"exclude_annotation_keys", []string{kubectlLastAppliedAnnotation})
 	includeAnnotationKeys := request.GetStringSlice("include_annotation_keys", []string{})
 
 	// Parse pagination parameters
@@ -196,7 +196,7 @@ func (m *Implementation) HandleListAllResources(ctx context.Context) ([]mcp.Reso
 				uri,
 				name,
 				mcp.WithResourceDescription(fmt.Sprintf("Kubernetes %s resource", apiResource.Kind)),
-				mcp.WithMIMEType("application/json"),
+				mcp.WithMIMEType(mimeTypeJSON),
 			)
 
 			resources = append(resources, resource)

--- a/pkg/mcp/post_resource.go
+++ b/pkg/mcp/post_resource.go
@@ -101,7 +101,7 @@ func parsePostResourceParams(request mcp.CallToolRequest) (*postResourceParams, 
 	if params.name == "" {
 		return nil, fmt.Errorf("name is required")
 	}
-	if params.resourceType == "namespaced" && params.namespace == "" {
+	if params.resourceType == resourceTypeNamespaced && params.namespace == "" {
 		return nil, fmt.Errorf("namespace is required for namespaced resources")
 	}
 	if params.bodyMap == nil {
@@ -109,7 +109,7 @@ func parsePostResourceParams(request mcp.CallToolRequest) (*postResourceParams, 
 	}
 
 	// Validate resource_type
-	if params.resourceType != "clustered" && params.resourceType != "namespaced" {
+	if params.resourceType != resourceTypeClustered && params.resourceType != resourceTypeNamespaced {
 		return nil, fmt.Errorf("invalid resource_type: %s", params.resourceType)
 	}
 

--- a/pkg/mcp/read_resource.go
+++ b/pkg/mcp/read_resource.go
@@ -154,7 +154,7 @@ func (m *Implementation) HandleClusteredResource(
 	return []mcp.ResourceContents{
 		mcp.TextResourceContents{
 			URI:      request.Params.URI,
-			MIMEType: "application/json",
+			MIMEType: mimeTypeJSON,
 			Text:     string(result),
 		},
 	}, nil
@@ -199,7 +199,7 @@ func (m *Implementation) HandleNamespacedResource(
 	return []mcp.ResourceContents{
 		mcp.TextResourceContents{
 			URI:      request.Params.URI,
-			MIMEType: "application/json",
+			MIMEType: mimeTypeJSON,
 			Text:     string(result),
 		},
 	}, nil

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -84,7 +84,7 @@ func NewClusteredResourceTemplate() mcp.ResourceTemplate {
 		"k8s://clustered/{group}/{version}/{resource}/{name}",
 		"Kubernetes Clustered Resource",
 		mcp.WithTemplateDescription("A Kubernetes clustered resource"),
-		mcp.WithTemplateMIMEType("application/json"),
+		mcp.WithTemplateMIMEType(mimeTypeJSON),
 	)
 }
 
@@ -94,6 +94,6 @@ func NewNamespacedResourceTemplate() mcp.ResourceTemplate {
 		"k8s://namespaced/{namespace}/{group}/{version}/{resource}/{name}",
 		"Kubernetes Namespaced Resource",
 		mcp.WithTemplateDescription("A Kubernetes namespaced resource"),
-		mcp.WithTemplateMIMEType("application/json"),
+		mcp.WithTemplateMIMEType(mimeTypeJSON),
 	)
 }


### PR DESCRIPTION
## Summary

- Brings `task lint` back to **zero issues** (was 50, all `goconst`).
- Bumps Go from **1.25.5 → 1.26.3** (latest stable). CI already uses `go-version-file: 'go.mod'`, so workflows pick this up automatically.

### Lint changes
- `.golangci.yml`: added `goconst` to the test-file exclusion list, matching the existing pattern for `dupl` / `paralleltest` / `gocyclo`. Test fixture strings are clearer inline than behind named constants.
- New `pkg/k8s/constants.go`: unexported constants for repeated Kubernetes JSON keys (`apiVersion`, `metadata`, `name`, `namespace`, `spec`, `status`, …) and values (`Pod`, `pods`, `exec`). `exec.go` and `subresource.go` now reference them.
- New `pkg/mcp/constants.go`: `resourceTypeClustered` / `resourceTypeNamespaced`, `mimeTypeJSON`, `kubectlLastAppliedAnnotation`. Used by `list_resources.go`, `post_resource.go`, `read_resource.go`, `tools.go`.
- `pkg/identity/identity.go`: added exported `DefaultUserClaim` / `DefaultGroupsClaim` constants used by `DefaultConfig()`.

### Go 1.26.3 changes
- `go.mod` bumped; `go mod tidy` pruned a couple of indirect deps.
- Go 1.26 deprecated direct access to `ecdsa.PublicKey.X` / `.Y`. Fixed in `pkg/identity/jwks_test.go` by switching to `pub.Bytes()` and slicing the uncompressed point into the X/Y halves the JWK encoding expects. The helper now takes `*testing.T` because `pub.Bytes()` returns an error.

## Test plan

- [x] `task lint` → 0 issues
- [x] `go build ./...`
- [x] `go test ./pkg/...` → all packages pass
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)