### PR TITLE
Cap pod log reads to prevent memory exhaustion

### DIFF
--- a/pkg/k8s/subresource.go
+++ b/pkg/k8s/subresource.go
@@ -14,6 +14,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// Pod log read limits guard against unbounded, attacker-controlled reads that
+// could exhaust server memory. Both the per-request parameters and the
+// in-memory copy of the log stream are capped.
+const (
+	// maxPodLogTailLines is the largest number of trailing log lines a caller
+	// may request via the tailLines parameter.
+	maxPodLogTailLines int64 = 1000
+	// maxPodLogLimitBytes is the largest log payload (in bytes) read into memory
+	// for a single request, both as a Kubernetes API limit and an application
+	// side hard cap.
+	maxPodLogLimitBytes int64 = 1024 * 1024 // 1 MB
+)
+
 // GetResource gets a resource or its subresource
 // If subresource is empty, the main resource is returned
 // parameters is a map of string key-value pairs that can be used to customize the request
@@ -110,11 +123,18 @@ func (c *Client) defaultGetPodLogs(
 		}
 	}()
 
-	// Read the logs
+	// Read the logs with a hard upper bound. Even though limitBytes is clamped
+	// when building the request options, wrap the stream in an io.LimitedReader
+	// as defense-in-depth so an oversized stream can never be fully buffered in
+	// memory.
 	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, podLogs)
+	limitedLogs := &io.LimitedReader{R: podLogs, N: maxPodLogLimitBytes + 1}
+	_, err = io.Copy(buf, limitedLogs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pod logs: %w", err)
+	}
+	if limitedLogs.N == 0 {
+		return nil, fmt.Errorf("pod logs exceed maximum size of %d bytes", maxPodLogLimitBytes)
 	}
 
 	// Create an unstructured object with the logs
@@ -167,19 +187,36 @@ func buildPodLogOpts(podLogOpts *corev1.PodLogOptions, parameters map[string]str
 		podLogOpts.Timestamps = timestampsBool
 	}
 
-	// Limit bytes (overrides default limit)
-	if limitBytes, ok := parameters["limitBytes"]; ok {
-		if b, err := strconv.ParseInt(limitBytes, 10, 64); err == nil {
-			podLogOpts.LimitBytes = &b
-		}
+	// Limit bytes (overrides default limit). Clamped to a safe upper bound so a
+	// caller cannot request an unbounded read.
+	if v := parseClampedInt64(parameters, "limitBytes", maxPodLogLimitBytes); v != nil {
+		podLogOpts.LimitBytes = v
 	}
 
-	// Tail lines (overrides default tail lines)
-	if tailLines, ok := parameters["tailLines"]; ok {
-		if lines, err := strconv.ParseInt(tailLines, 10, 64); err == nil {
-			podLogOpts.TailLines = &lines
-		}
+	// Tail lines (overrides default tail lines). Clamped to a safe upper bound so
+	// a caller cannot request an unbounded read.
+	if v := parseClampedInt64(parameters, "tailLines", maxPodLogTailLines); v != nil {
+		podLogOpts.TailLines = v
 	}
 
 	return *podLogOpts
+}
+
+// parseClampedInt64 parses an integer parameter and clamps it to (0, max].
+// Non-positive or oversized values are clamped to max so an attacker cannot
+// request an unbounded pod log read. It returns nil if the parameter is absent
+// or not a valid integer, leaving any existing default in place.
+func parseClampedInt64(parameters map[string]string, key string, maxValue int64) *int64 {
+	raw, ok := parameters[key]
+	if !ok {
+		return nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return nil
+	}
+	if v <= 0 || v > maxValue {
+		v = maxValue
+	}
+	return &v
 }

--- a/pkg/k8s/subresource_test.go
+++ b/pkg/k8s/subresource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -187,6 +188,115 @@ func TestGetResource(t *testing.T) {
 	// Note: The fake client doesn't fully support subresources in the same way as the real client,
 	// so we're not testing subresource functionality here. In a real environment, the subresource
 	// parameter would be passed to the Get method and the appropriate subresource would be returned.
+}
+
+func TestBuildPodLogOpts_ClampsLimitBytes(t *testing.T) {
+	// Regression test: attacker-controlled limitBytes must be clamped to a safe
+	// upper bound to prevent unbounded in-memory log reads (memory exhaustion / DoS).
+	testCases := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{
+			name:     "value within range is preserved",
+			input:    "4096",
+			expected: 4096,
+		},
+		{
+			name:     "value at the maximum is preserved",
+			input:    "1048576", // maxPodLogLimitBytes (1 MB)
+			expected: maxPodLogLimitBytes,
+		},
+		{
+			name:     "value above the maximum is clamped",
+			input:    "2147483647", // ~2 GB attacker value
+			expected: maxPodLogLimitBytes,
+		},
+		{
+			name:     "max int64 is clamped",
+			input:    "9223372036854775807",
+			expected: maxPodLogLimitBytes,
+		},
+		{
+			name:     "zero is clamped to the maximum",
+			input:    "0",
+			expected: maxPodLogLimitBytes,
+		},
+		{
+			name:     "negative value is clamped to the maximum",
+			input:    "-1",
+			expected: maxPodLogLimitBytes,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &corev1.PodLogOptions{}
+			opts := buildPodLogOpts(base, map[string]string{"limitBytes": tc.input})
+
+			assert.NotNil(t, opts.LimitBytes)
+			assert.Equal(t, tc.expected, *opts.LimitBytes)
+		})
+	}
+}
+
+func TestBuildPodLogOpts_LimitBytesNonNumericLeavesDefault(t *testing.T) {
+	// A non-numeric value fails to parse and must leave the existing
+	// (safe) default in place rather than clearing the cap.
+	defaultLimit := int64(32 * 1024)
+	base := &corev1.PodLogOptions{LimitBytes: &defaultLimit}
+
+	opts := buildPodLogOpts(base, map[string]string{"limitBytes": "not-a-number"})
+
+	assert.NotNil(t, opts.LimitBytes)
+	assert.Equal(t, defaultLimit, *opts.LimitBytes)
+}
+
+func TestBuildPodLogOpts_ClampsTailLines(t *testing.T) {
+	// Regression test: attacker-controlled tailLines must be clamped to a safe
+	// upper bound.
+	testCases := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{
+			name:     "value within range is preserved",
+			input:    "50",
+			expected: 50,
+		},
+		{
+			name:     "value at the maximum is preserved",
+			input:    "1000", // maxPodLogTailLines
+			expected: maxPodLogTailLines,
+		},
+		{
+			name:     "value above the maximum is clamped",
+			input:    "999999999",
+			expected: maxPodLogTailLines,
+		},
+		{
+			name:     "zero is clamped to the maximum",
+			input:    "0",
+			expected: maxPodLogTailLines,
+		},
+		{
+			name:     "negative value is clamped to the maximum",
+			input:    "-5",
+			expected: maxPodLogTailLines,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &corev1.PodLogOptions{}
+			opts := buildPodLogOpts(base, map[string]string{"tailLines": tc.input})
+
+			assert.NotNil(t, opts.TailLines)
+			assert.Equal(t, tc.expected, *opts.TailLines)
+		})
+	}
 }
 
 func TestGetPodLogs(t *testing.T) {


### PR DESCRIPTION
## Summary

The `get_resource` MCP tool proxies pod log requests and previously forwarded the caller-supplied `limitBytes` and `tailLines` parameters to the Kubernetes API without any upper bound, then read the entire returned stream into an in-memory `bytes.Buffer`. A single request could therefore drive unbounded in-memory reads and exhaust the server's memory (OOM), causing a denial of service.

This change caps both the request parameters and the in-memory read.

<details>
<summary><strong>Medium level</strong></summary>

- Clamp `limitBytes` to a 1 MB maximum and `tailLines` to a 1000-line maximum, treating non-positive or oversized values as the cap.
- Wrap the log stream copy in an `io.LimitedReader` as defense-in-depth, returning an error if a stream exceeds the cap rather than buffering it all.
- Extract the parse-and-clamp logic into a small `parseClampedInt64` helper to avoid duplication and keep cyclomatic complexity within lint limits.
- Add regression tests covering in-range, at-max, over-max, max-int64, zero, negative, and non-numeric inputs for both parameters.

</details>

<details>
<summary><strong>Low level</strong></summary>

| File | Change |
|------|--------|
| `pkg/k8s/subresource.go` | Add `maxPodLogTailLines` / `maxPodLogLimitBytes` constants, clamp parameters via `parseClampedInt64`, and bound the stream copy with `io.LimitedReader` |
| `pkg/k8s/subresource_test.go` | Add table-driven tests for `limitBytes` / `tailLines` clamping and non-numeric handling |

</details>

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Test plan

- [x] `task lint-fix` passes (0 issues)
- [x] `task test` passes
- [x] `task build` passes
- [x] New unit tests added for parameter clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)